### PR TITLE
Simplify election algorithm to prioritize recent approvals

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,21 +36,20 @@ This is a CLI tool called "review" that automatically selects the next code revi
 - **GitHub Integration**: `src/lib/github.js` - Interfaces with GitHub CLI (`gh`)
 - **Reviewer Selection**: `src/lib/reviewer-selector.js` - Core scoring algorithm
 
-### Scoring Algorithm
-The `ReviewerSelector` class uses weighted scoring prioritizing approvals over reviews:
-- **Approval Recency** (weight: 5) - Days since last approval (primary factor)
-- **Review Recency** (weight: 1) - Days since any review activity
-- **Approval Balance** (weight: 1) - PR approval count distribution across team
-- **Workload** (weight: 1) - Current pending reviews penalty
+### Selection Algorithm
+The `ReviewerSelector` class uses a simple algorithm focused on approval rotation:
+- Analyzes the last N PRs (default: 10) for approval patterns
+- Prioritizes reviewers with fewer recent approvals
+- Breaks ties by who approved longest ago
+- Applies workload penalties for pending reviews
 
 ### Configuration File Structure
 `.pr-reviewer.yml` contains:
 - `team` - Array of eligible reviewers
 - `excluded` - Bot accounts to ignore
-- `weights` - Scoring weight configuration
-- `unavailable` - Temporary unavailability records
-- `historyDays` - Review history window (default: 30)
+- `lookbackPRs` - Number of recent PRs to analyze (default: 10)
 - `maxPendingReviews` - Workload threshold (default: 3)
+- `unavailable` - Temporary unavailability records
 
 ### Key Dependencies
 - `commander` - CLI framework

--- a/README.md
+++ b/README.md
@@ -125,18 +125,10 @@ excluded:
   - dependabot[bot]
   - github-actions[bot]
 
-# Scoring weights
-weights:
-  recency: 1      # Days since last review (comment/changes requested)
-  balance: 1      # PR approval count balance across team
-  approvals: 5    # Days since last approval (primary factor)
-  workload: 1     # Current pending reviews penalty
+# Configuration settings
+lookbackPRs: 10         # Number of recent PRs to analyze for approval patterns
+maxPendingReviews: 3    # Max pending reviews before reviewer is deprioritized
 
-# Review history window (days)
-historyDays: 30
-
-# Maximum pending reviews before deprioritizing
-maxPendingReviews: 3
 
 # Unavailable team members
 unavailable:
@@ -145,16 +137,16 @@ unavailable:
     until: "2024-01-20T10:00:00Z"
 ```
 
-## Scoring Algorithm
+## Selection Algorithm
 
-The tool uses a weighted scoring system to select reviewers, prioritizing approval activity over general review activity:
+The tool uses a simple, transparent algorithm focused on minimizing repeats and load balancing approvals:
 
-1. **Approval Recency** (default weight: 5): Primary factor - prefers reviewers who haven't approved a PR in the longest time
-2. **Review Recency** (default weight: 1): Secondary factor - considers days since any review activity (comments, changes requested)  
-3. **Approval Balance** (default weight: 1): Distributes PR approvals evenly across the team
-4. **Workload** (default weight: 1): Deprioritizes reviewers with many pending reviews
+1. **Looks at the last N PRs** (default: 10) to see who has been approving recently
+2. **Prioritizes reviewers with fewer recent approvals** - if someone hasn't approved any of the last 10 PRs, they get top priority
+3. **Breaks ties by recency** - among reviewers with the same approval count, picks who approved longest ago
+4. **Considers current workload** - adds penalty for pending reviews, heavy penalty for exceeding max pending reviews
 
-The scoring system heavily prioritizes getting approvals from team members who haven't approved recently, while still considering general review activity. This ensures that team members who tend to comment without approving don't monopolize the review queue.
+This simple approach ensures fair rotation of approvals (not just comments) and prevents the same people from always being selected while others are skipped.
 
 ## Development
 

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -40,16 +40,9 @@ class Config {
     return {
       team: [],
       excluded: ['dependabot[bot]', 'github-actions[bot]'],
-      weights: {
-        recency: 1,     // Days since last review (comment/changes requested)
-        balance: 1,     // Approval count balance across team
-        approvals: 5,   // Days since last approval (primary factor)
-        workload: 1     // Current pending reviews penalty
-      },
-      unavailable: {},
-      minReviewsBeforeReset: 5,
-      historyDays: 30,
-      maxPendingReviews: 3
+      lookbackPRs: 10,        // Number of recent PRs to analyze for approval patterns
+      maxPendingReviews: 3,   // Max pending reviews before reviewer is deprioritized
+      unavailable: {}
     };
   }
 

--- a/tests/reviewer-selector.test.js
+++ b/tests/reviewer-selector.test.js
@@ -1,13 +1,24 @@
 const ReviewerSelector = require('../src/lib/reviewer-selector');
 
+// Mock the config module
+jest.mock('../src/lib/config', () => ({
+  get: () => ({
+    team: ['alice', 'bob', 'charlie', 'david'],
+    excluded: ['dependabot[bot]'],
+    lookbackPRs: 10,
+    maxPendingReviews: 3
+  }),
+  isUnavailable: () => false
+}));
+
 describe('ReviewerSelector', () => {
   const mockPRHistory = [
     {
-      number: 1,
+      number: 3,
       author: { login: 'alice' },
-      closedAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(),
+      closedAt: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString(),
       reviews: [
-        { author: { login: 'bob' }, submittedAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString() }
+        { author: { login: 'bob' }, state: 'APPROVED', submittedAt: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString() }
       ]
     },
     {
@@ -15,15 +26,23 @@ describe('ReviewerSelector', () => {
       author: { login: 'bob' },
       closedAt: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
       reviews: [
-        { author: { login: 'charlie' }, submittedAt: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString() },
-        { author: { login: 'alice' }, submittedAt: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString() }
+        { author: { login: 'charlie' }, state: 'COMMENTED', submittedAt: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString() },
+        { author: { login: 'alice' }, state: 'APPROVED', submittedAt: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString() }
+      ]
+    },
+    {
+      number: 1,
+      author: { login: 'charlie' },
+      closedAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(),
+      reviews: [
+        { author: { login: 'bob' }, state: 'APPROVED', submittedAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString() }
       ]
     }
   ];
 
   const mockOpenPRs = [
     {
-      number: 3,
+      number: 4,
       author: { login: 'charlie' },
       reviewRequests: [{ login: 'bob' }]
     }
@@ -35,82 +54,117 @@ describe('ReviewerSelector', () => {
     selector = new ReviewerSelector(mockPRHistory, mockOpenPRs);
   });
 
-  describe('calculateReviewStats', () => {
-    test('should calculate correct review counts', () => {
-      const stats = selector.reviewStats;
-      expect(stats.bob.totalReviews).toBe(1);
-      expect(stats.charlie.totalReviews).toBe(1);
-      expect(stats.alice.totalReviews).toBe(1);
+  describe('getRecentApprovals', () => {
+    test('should return approvals from recent PRs sorted by date', () => {
+      const approvals = selector.getRecentApprovals();
+      expect(approvals.length).toBe(3);
+      expect(approvals[0].reviewer).toBe('bob'); // Most recent approval
+      expect(approvals[0].prNumber).toBe(3);
+      expect(approvals[1].reviewer).toBe('alice');
+      expect(approvals[2].reviewer).toBe('bob');
     });
+  });
 
-    test('should calculate days since last review', () => {
-      const stats = selector.reviewStats;
-      expect(stats.bob.daysSinceLastReview).toBe(5);
-      expect(stats.charlie.daysSinceLastReview).toBe(3);
-      expect(stats.alice.daysSinceLastReview).toBe(3);
-    });
-
-    test('should track pending reviews', () => {
-      const stats = selector.reviewStats;
-      expect(stats.bob.pendingReviews).toBe(1);
-      expect(stats.charlie?.pendingReviews || 0).toBe(0);
-      expect(stats.alice?.pendingReviews || 0).toBe(0);
+  describe('getPendingReviews', () => {
+    test('should track current pending review requests', () => {
+      const pending = selector.getPendingReviews();
+      expect(pending.bob).toBe(1);
+      expect(pending.alice).toBeUndefined();
+      expect(pending.charlie).toBeUndefined();
     });
   });
 
   describe('getEligibleReviewers', () => {
     test('should exclude PR author', () => {
-      const eligible = selector.getEligibleReviewers('alice', ['alice', 'bob', 'charlie']);
+      const eligible = selector.getEligibleReviewers('alice');
       expect(eligible).not.toContain('alice');
       expect(eligible).toContain('bob');
       expect(eligible).toContain('charlie');
+      expect(eligible).toContain('david');
     });
 
     test('should exclude bot accounts', () => {
-      const eligible = selector.getEligibleReviewers('alice', ['alice', 'bob', 'dependabot[bot]']);
+      const eligible = selector.getEligibleReviewers('alice');
       expect(eligible).not.toContain('dependabot[bot]');
     });
   });
 
-  describe('calculateScore', () => {
-    test('should give higher score to reviewer with longer time since last review', () => {
-      const bobScore = selector.calculateScore('bob').score;
-      const charlieScore = selector.calculateScore('charlie').score;
-      
-      expect(bobScore).toBeGreaterThan(charlieScore);
-    });
-
-    test('should penalize reviewers with pending reviews', () => {
-      const davidScore = selector.calculateScore('david').score;
-      const bobScore = selector.calculateScore('bob').score;
-      
-      expect(davidScore).toBeGreaterThan(bobScore);
-    });
-  });
-
   describe('selectReviewer', () => {
-    test('should select eligible reviewer with highest score', () => {
-      const mockConfig = {
-        get: () => ({
-          team: ['alice', 'bob', 'charlie', 'david'],
-          excluded: [],
-          weights: { recency: 3, balance: 2, workload: 1 },
-          maxPendingReviews: 3
-        }),
-        isUnavailable: () => false
-      };
-      
-      jest.mock('../src/lib/config', () => mockConfig);
-      
-      const result = selector.selectReviewer('alice');
+    test('should select reviewer with fewest recent approvals', () => {
+      const result = selector.selectReviewer('eve'); // Author not in team
       expect(result).toBeDefined();
       expect(result.reviewer).toBeDefined();
-      expect(['bob', 'charlie', 'david']).toContain(result.reviewer);
+      
+      // Charlie and David have 0 recent approvals, should be prioritized over Alice (1) and Bob (2)
+      expect(['charlie', 'david']).toContain(result.reviewer);
+    });
+
+    test('should prefer reviewer who approved longest ago when approval counts are equal', () => {
+      // Both Charlie and David have 0 approvals, but we need to check tie-breaking logic
+      const result = selector.selectReviewer('eve');
+      expect(result).toBeDefined();
+      expect(['charlie', 'david']).toContain(result.reviewer);
     });
 
     test('should return null when no eligible reviewers', () => {
-      const result = selector.selectReviewer('alice', ['alice']);
+      // Mock config to return empty team
+      const originalConfig = require('../src/lib/config');
+      originalConfig.get = jest.fn(() => ({
+        team: [],
+        excluded: [],
+        lookbackPRs: 10,
+        maxPendingReviews: 3
+      }));
+
+      const result = selector.selectReviewer('alice');
       expect(result).toBeNull();
+    });
+
+    test('should penalize reviewers with too many pending reviews', () => {
+      // Create a reviewer with many pending reviews
+      const mockOpenPRsWithManyPending = [
+        { reviewRequests: [{ login: 'charlie' }] },
+        { reviewRequests: [{ login: 'charlie' }] },
+        { reviewRequests: [{ login: 'charlie' }] },
+        { reviewRequests: [{ login: 'charlie' }] } // 4 pending, over the limit
+      ];
+      
+      const selectorWithPending = new ReviewerSelector(mockPRHistory, mockOpenPRsWithManyPending);
+      const result = selectorWithPending.selectReviewer('eve');
+      
+      expect(result).toBeDefined();
+      expect(result.reviewer).not.toBe('charlie'); // Should not select overloaded reviewer
+      expect(['alice', 'bob', 'david']).toContain(result.reviewer);
+    });
+  });
+
+  describe('calculateReviewStats', () => {
+    test('should calculate recent approval counts correctly', () => {
+      const stats = selector.calculateReviewStats();
+      
+      expect(stats.alice).toBeDefined();
+      expect(stats.alice.recentApprovals).toBe(1);
+      expect(stats.bob.recentApprovals).toBe(2);
+      expect(stats.charlie.recentApprovals).toBe(0);
+      expect(stats.david.recentApprovals).toBe(0);
+    });
+
+    test('should track pending reviews correctly', () => {
+      const stats = selector.calculateReviewStats();
+      
+      expect(stats.bob.pendingReviews).toBe(1);
+      expect(stats.alice.pendingReviews).toBe(0);
+      expect(stats.charlie.pendingReviews).toBe(0);
+      expect(stats.david.pendingReviews).toBe(0);
+    });
+
+    test('should track last approval dates', () => {
+      const stats = selector.calculateReviewStats();
+      
+      expect(stats.alice.lastApprovalDate).toBeDefined();
+      expect(stats.bob.lastApprovalDate).toBeDefined();
+      expect(stats.charlie.lastApprovalDate).toBeNull();
+      expect(stats.david.lastApprovalDate).toBeNull();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Replaces complex weighted scoring system with simple approval-based selection
- Analyzes the last N PRs (default: 10) to see who has been approving recently  
- Prioritizes reviewers with fewer recent approvals to minimize repeats and ensure fair rotation
- Breaks ties by selecting who approved longest ago

## Key Changes
### Algorithm Simplification
- **Before**: Complex scoring with weights for recency, balance, approvals, and workload
- **After**: Simple scoring based on recent approval count + pending review penalty
- Eliminates hard-to-understand weighted calculations in favor of transparent logic

### Configuration Updates
- Removed weights, historyDays, minReviewsBeforeReset 
- Added lookbackPRs: 10 - number of recent PRs to analyze for patterns
- Kept maxPendingReviews: 3 - workload threshold

### Command Updates
- **review elect**: Shows recent approvals vs total PRs analyzed, approval status, selection score
- **review stats**: Displays approval-focused metrics with Next up status for those with 0 recent approvals
- **review next**: Shows approval status and recent approval counts instead of complex scoring breakdown

### Bug Fixes
- Fixed getAverageReviews is not a function error by removing deprecated methods
- Updated all commands to use the simplified stats structure

## Benefits
- **Transparent**: Easy to understand who gets selected and why
- **Fair**: Ensures people who haven't approved recently get priority
- **Focused**: Prioritizes actual approvals over comments/change requests
- **Simple**: Removes complex configuration and scoring weights