### PR TITLE
Increase lookbackPRs from 10 to 30

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ This is a CLI tool called "review" that automatically selects the next code revi
 
 ### Selection Algorithm
 The `ReviewerSelector` class uses a simple algorithm focused on approval rotation:
-- Analyzes the last N PRs (default: 10) for approval patterns
+- Analyzes the last N PRs (default: 30) for approval patterns
 - Prioritizes reviewers with fewer recent approvals
 - Breaks ties by who approved longest ago
 - Applies workload penalties for pending reviews
@@ -47,7 +47,7 @@ The `ReviewerSelector` class uses a simple algorithm focused on approval rotatio
 `.pr-reviewer.yml` contains:
 - `team` - Array of eligible reviewers
 - `excluded` - Bot accounts to ignore
-- `lookbackPRs` - Number of recent PRs to analyze (default: 10)
+- `lookbackPRs` - Number of recent PRs to analyze (default: 30)
 - `maxPendingReviews` - Workload threshold (default: 3)
 - `unavailable` - Temporary unavailability records
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ excluded:
   - github-actions[bot]
 
 # Configuration settings
-lookbackPRs: 10         # Number of recent PRs to analyze for approval patterns
+lookbackPRs: 30         # Number of recent PRs to analyze for approval patterns
 maxPendingReviews: 3    # Max pending reviews before reviewer is deprioritized
 
 
@@ -141,8 +141,8 @@ unavailable:
 
 The tool uses a simple, transparent algorithm focused on minimizing repeats and load balancing approvals:
 
-1. **Looks at the last N PRs** (default: 10) to see who has been approving recently
-2. **Prioritizes reviewers with fewer recent approvals** - if someone hasn't approved any of the last 10 PRs, they get top priority
+1. **Looks at the last N PRs** (default: 30) to see who has been approving recently
+2. **Prioritizes reviewers with fewer recent approvals** - if someone hasn't approved any of the last 30 PRs, they get top priority
 3. **Breaks ties by recency** - among reviewers with the same approval count, picks who approved longest ago
 4. **Considers current workload** - adds penalty for pending reviews, heavy penalty for exceeding max pending reviews
 

--- a/src/commands/elect.js
+++ b/src/commands/elect.js
@@ -51,7 +51,7 @@ async function elect(options) {
     spinner.succeed('Analysis complete');
     
     const cfg = config.get();
-    const lookbackPRs = cfg.lookbackPRs || 10;
+    const lookbackPRs = cfg.lookbackPRs || 30;
     const lastApprovalIndex = result.stats.lastApprovalIndex;
     const approvalStatus = lastApprovalIndex >= lookbackPRs 
       ? 'No recent approvals' 

--- a/src/commands/next.js
+++ b/src/commands/next.js
@@ -25,7 +25,7 @@ async function next(options) {
     spinner.succeed('Review queue analyzed');
     
     const cfg = config.get();
-    const lookbackPRs = cfg.lookbackPRs || 10;
+    const lookbackPRs = cfg.lookbackPRs || 30;
     
     console.log(boxen(
       chalk.bold('📊 Next Reviewers in Queue\n\n') +

--- a/src/commands/stats.js
+++ b/src/commands/stats.js
@@ -38,7 +38,7 @@ async function stats(options) {
     });
     
     const cfg = config.get();
-    const lookbackPRs = cfg.lookbackPRs || 10;
+    const lookbackPRs = cfg.lookbackPRs || 30;
     
     const sortedReviewers = Object.entries(reviewStats)
       .filter(([reviewer]) => !reviewer.includes('[bot]'))

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -40,7 +40,7 @@ class Config {
     return {
       team: [],
       excluded: ['dependabot[bot]', 'github-actions[bot]'],
-      lookbackPRs: 10,        // Number of recent PRs to analyze for approval patterns
+      lookbackPRs: 30,        // Number of recent PRs to analyze for approval patterns
       maxPendingReviews: 3,   // Max pending reviews before reviewer is deprioritized
       unavailable: {}
     };

--- a/src/lib/reviewer-selector.js
+++ b/src/lib/reviewer-selector.js
@@ -9,7 +9,7 @@ class ReviewerSelector {
   // Get the last N PRs and track who approved them
   getRecentApprovals() {
     const cfg = config.get();
-    const lookbackPRs = cfg.lookbackPRs || 10;
+    const lookbackPRs = cfg.lookbackPRs || 30;
     
     // Sort PRs by most recent first, then take the last N
     const recentPRs = this.prHistory

--- a/tests/reviewer-selector.test.js
+++ b/tests/reviewer-selector.test.js
@@ -5,7 +5,7 @@ jest.mock('../src/lib/config', () => ({
   get: () => ({
     team: ['alice', 'bob', 'charlie', 'david'],
     excluded: ['dependabot[bot]'],
-    lookbackPRs: 10,
+    lookbackPRs: 30,
     maxPendingReviews: 3
   }),
   isUnavailable: () => false
@@ -112,7 +112,7 @@ describe('ReviewerSelector', () => {
       originalConfig.get = jest.fn(() => ({
         team: [],
         excluded: [],
-        lookbackPRs: 10,
+        lookbackPRs: 30,
         maxPendingReviews: 3
       }));
 


### PR DESCRIPTION
- Updated default lookbackPRs configuration from 10 to 30 PRs
- Updated all fallback values in commands and reviewer-selector
- Updated documentation in README.md and CLAUDE.md
- Updated test configurations to match new default
- Now analyzes approval patterns from the last 30 PRs instead of 10

🤖 Generated with [Claude Code](https://claude.ai/code)